### PR TITLE
feat: check for op executable

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,13 @@ func initConfig() {
 }
 
 func init() {
+	if helpers.Which("op") == "" {
+		fmt.Println("Missing op executable")
+		fmt.Println("Please follow the instructions for install the binaries here:")
+		fmt.Print("\nhttps://developer.1password.com/docs/cli/get-started\n\n")
+		os.Exit(1)
+	}
+
 	cobra.OnInitialize(initConfig)
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.opsi.yaml)")
 }

--- a/helpers/which.go
+++ b/helpers/which.go
@@ -1,0 +1,35 @@
+package helpers
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+)
+
+func Which(command string) string {
+	response, err := Exec("which", command)
+	if err != nil {
+		return ""
+	}
+
+	return string(response)
+}
+
+func Exec(command string, args ...string) ([]byte, error) {
+	var stderr, stdout bytes.Buffer
+	cmd := exec.Command(command, args...)
+
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+
+	err := cmd.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	if stderr.String() != "" {
+		return nil, errors.New(stderr.String())
+	}
+
+	return stdout.Bytes(), nil
+}


### PR DESCRIPTION
Prevent user to use the CLI if some binaries are not installed