### PR TITLE
Feat/gitlab features

### DIFF
--- a/cmd/gitlabCreateGroupCmd.go
+++ b/cmd/gitlabCreateGroupCmd.go
@@ -29,6 +29,9 @@ var gitlabCreateGroupCmd = &cobra.Command{
 		// Take the pathname from the flag
 		pathname, _ := cmd.Flags().GetString("path")
 
+		// Take the visibility from the flag
+		visibility, _ := cmd.Flags().GetString("visibility")
+
 		// If the pathname is not provided
 		// let the system slugify the name
 		if pathname == "" {
@@ -36,7 +39,7 @@ var gitlabCreateGroupCmd = &cobra.Command{
 		}
 
 		// Create subgroup
-		groupID, err := gitlab.CreateSubgroup(name, pathname, nil)
+		groupID, err := gitlab.CreateGroup(name, pathname, visibility)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -49,4 +52,5 @@ var gitlabCreateGroupCmd = &cobra.Command{
 func init() {
 	gitlabCreateCmd.AddCommand(gitlabCreateGroupCmd)
 	gitlabCreateGroupCmd.Flags().StringP("path", "p", "", "The slugify name for the group")
+	gitlabCreateGroupCmd.Flags().StringP("visibility", "i", "private", "Set the visibility of the group")
 }

--- a/cmd/gitlabCreateGroupCmd.go
+++ b/cmd/gitlabCreateGroupCmd.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	slugify "github.com/mozillazg/go-slugify"
+	"github.com/spf13/cobra"
+)
+
+var gitlabCreateGroupCmd = &cobra.Command{
+	Use:   "group {group_name}",
+	Args:  cobra.ExactArgs(1),
+	Short: "Create a Gitlab group",
+	Long:  "Create a Gitlab group",
+	Example: `
+  Create a group with name "research"
+  opsi gitlab create group research
+
+  ---
+
+  Create a group with name "development" but with path to "devs"
+  opsi gitlab create group development -p devs
+	`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Take the name of the group
+		name := args[0]
+
+		// Take the pathname from the flag
+		pathname, _ := cmd.Flags().GetString("path")
+
+		// If the pathname is not provided
+		// let the system slugify the name
+		if pathname == "" {
+			pathname = slugify.Slugify(name)
+		}
+
+		// Create subgroup
+		groupID, err := gitlab.CreateSubgroup(name, pathname, nil)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		fmt.Println("Created new group with ID", groupID)
+	},
+}
+
+func init() {
+	gitlabCreateCmd.AddCommand(gitlabCreateGroupCmd)
+	gitlabCreateGroupCmd.Flags().StringP("path", "p", "", "The slugify name for the group")
+}

--- a/cmd/gitlabCreateGroupCmd.go
+++ b/cmd/gitlabCreateGroupCmd.go
@@ -21,6 +21,11 @@ var gitlabCreateGroupCmd = &cobra.Command{
 
   Create a group with name "development" but with path to "devs"
   opsi gitlab create group development -p devs
+
+  ---
+
+  Create a group with name "development" with "public" visibility
+  opsi gitlab create group development -i public
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Take the name of the group

--- a/cmd/gitlabCreateProjectCmd.go
+++ b/cmd/gitlabCreateProjectCmd.go
@@ -27,6 +27,12 @@ var gitlabCreateProjectCmd = &cobra.Command{
 
   Create a project with name "Valerian" using "master" as default branch
   opsi gitlab create project Valerian -b master
+
+  ---
+
+  Create a project with name "Akkadian" enabling mirroring to another gitlab
+  opsi gitlab create project Akkadian -m
+
 	`,
 
 	Run: func(cmd *cobra.Command, args []string) {
@@ -37,6 +43,7 @@ var gitlabCreateProjectCmd = &cobra.Command{
 		group, _ := cmd.Flags().GetInt("group")
 		pathname, _ := cmd.Flags().GetString("path")
 		defaultBranch, _ := cmd.Flags().GetString("branch-default")
+		mirror, _ := cmd.Flags().GetBool("mirror")
 
 		// Slugify the name if the pathname flag
 		// for the project is not provided
@@ -45,7 +52,7 @@ var gitlabCreateProjectCmd = &cobra.Command{
 		}
 
 		// Create the project
-		projectID, err := gitlab.CreateProject(name, pathname, group, defaultBranch)
+		projectID, err := gitlab.CreateProject(name, pathname, group, defaultBranch, mirror)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -60,6 +67,7 @@ func init() {
 	gitlabCreateProjectCmd.Flags().IntP("group", "s", 0, "the group associated to the project. If not provided the one in the configuration will be used")
 	gitlabCreateProjectCmd.Flags().StringP("path", "p", "", "the path for the project. This flag is useful if you don't want to use the project name for the path")
 	gitlabCreateProjectCmd.Flags().StringP("branch-default", "b", "main", "the default main branch. Possible values are master or main")
+	gitlabCreateProjectCmd.Flags().BoolP("mirror", "m", false, "Enable or disable the mirroring repo. Default is false")
 
 	// Mark group as required
 	gitlabCreateProjectCmd.MarkFlagRequired("group")

--- a/cmd/gitlabCreateProjectCmd.go
+++ b/cmd/gitlabCreateProjectCmd.go
@@ -60,4 +60,7 @@ func init() {
 	gitlabCreateProjectCmd.Flags().IntP("group", "s", 0, "the group associated to the project. If not provided the one in the configuration will be used")
 	gitlabCreateProjectCmd.Flags().StringP("path", "p", "", "the path for the project. This flag is useful if you don't want to use the project name for the path")
 	gitlabCreateProjectCmd.Flags().StringP("branch-default", "b", "main", "the default main branch. Possible values are master or main")
+
+	// Mark group as required
+	gitlabCreateProjectCmd.MarkFlagRequired("group")
 }

--- a/cmd/gitlabCreateSubgroupCmd.go
+++ b/cmd/gitlabCreateSubgroupCmd.go
@@ -15,17 +15,12 @@ var gitlabCreateSubgroupCmd = &cobra.Command{
 	Long:  "Create a Gitlab subgroup",
 	Example: `
   Create a subgroup with name "research" attach to a specific group with id 1234
-  opsi gitlab create subgroup research -p 1234 
-
-  ---
-
-  Create a subgroup with name "developments" to the root of the space
-  opsi gitlab create subgroup developments 
+  opsi gitlab create subgroup research -s 1234 
 
   ---
 
   Create a subgroup with name "development" but with path to "devs"
-  opsi gitlab create subgroup development -p devs
+  opsi gitlab create subgroup development -p devs -s 1234
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Take the name of the group
@@ -64,4 +59,7 @@ func init() {
 	gitlabCreateCmd.AddCommand(gitlabCreateSubgroupCmd)
 	gitlabCreateSubgroupCmd.Flags().IntP("parent", "s", 0, "The parent of the subgroup you want create")
 	gitlabCreateSubgroupCmd.Flags().StringP("path", "p", "", "The slugify name for the subgroup")
+
+	// Mark group as required
+	gitlabCreateSubgroupCmd.MarkFlagRequired("parent")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,7 @@ func initConfig() {
 	gitlab = git.NewGitlab(
 		mainConfig.Gitlab.ApiURL,
 		mainConfig.Gitlab.Token,
+		mainConfig.Gitlab.Mirror,
 	)
 
 	onepassword = op.NewOnePassword(mainConfig.OnePassword.Address)

--- a/config/defs.go
+++ b/config/defs.go
@@ -1,5 +1,7 @@
 package config
 
+import "opsi/scopes/gitlab"
+
 type ConfigPostamark struct {
 	Token        string `mapstructure:"token"`
 	SlackWebhook string `mapstructure:"slack_webhook"`
@@ -7,8 +9,9 @@ type ConfigPostamark struct {
 }
 
 type ConfigGitlab struct {
-	Token  string `mapstructure:"token"`
-	ApiURL string `mapstructure:"api_url"`
+	Token  string                     `mapstructure:"token"`
+	ApiURL string                     `mapstructure:"api_url"`
+	Mirror gitlab.GitlabMirrorOptions `mapstructure:"mirror"`
 }
 
 type ConfigOnePassword struct {

--- a/config/template.yml
+++ b/config/template.yml
@@ -1,6 +1,12 @@
 gitlab:
-  api_url: "https://gitlab.com/api/v4"
+  api_url: "https://company.gitlab.com/api/v4"
   token: "<GITLAB_TOKEN>"
+  mirror:
+    url: "https://gitlab.com/api/v4"
+    group_id: "<GITLAB_MIRROR_GROUP_ID>"
+    group_path: "gitlab.com/<GROUP_NAME>"  
+    username: "<GITLAB_MIRROR_USERNAME>"
+    token: "<GITLAB_MIRROR_TOKEN>"
 postmark:
   api_url: "https://api.postmarkapp.com"
   token: <POSTMARK_TOKEN>

--- a/scopes/gitlab/defs.go
+++ b/scopes/gitlab/defs.go
@@ -7,17 +7,33 @@ const gitlabDefaultGroupMember string = "default_group_member"
 type gitlab struct {
 	token  string
 	apiURL string
+	mirror GitlabMirrorOptions
 }
 
 type Gitlab interface {
 	CreateEnvs(string, string, string) error
 	ListEnvs(string, string) error
 	DeleteEnvs(string, string) error
-	CreateProject(string, string, int, string) (int, error)
+	CreateProject(string, string, int, string, bool) (int, error)
 	CreateSubgroup(string, string, *int) (int, error)
 	CreateGroup(string, string, string) (int, error)
 	BulkSettings(*chan string) error
 	Deprovionioning(string) error
+}
+
+type GitlabMirrorOptions struct {
+	Token     string `mapstructure:"token"`
+	ApiURL    string `mapstructure:"api_url"`
+	GroupPath string `mapstructure:"group_path"`
+	Username  string `mapstructure:"username"`
+	Password  string `mapstructure:"password"`
+	GroupID   int    `mapstructure:"group_id"`
+}
+
+type gitlabCreateMirrorRequest struct {
+	Enabled               bool   `json:"enabled"`
+	URL                   string `json:"url"`
+	OnlyProtectedBranched bool   `json:"only_protected_branches"`
 }
 
 type gitlabCreateSubgroupRequest struct {

--- a/scopes/gitlab/defs.go
+++ b/scopes/gitlab/defs.go
@@ -15,6 +15,7 @@ type Gitlab interface {
 	DeleteEnvs(string, string) error
 	CreateProject(string, string, int, string) (int, error)
 	CreateSubgroup(string, string, *int) (int, error)
+	CreateGroup(string, string, string) (int, error)
 	BulkSettings(*chan string) error
 	Deprovionioning(string) error
 }
@@ -30,7 +31,9 @@ type gitlabCreateSubgroupRequest struct {
 }
 
 type gitlabSubgroupResponse struct {
-	ID int `json:"id"`
+	ID                   int    `json:"id"`
+	Visibility           string `json:"visibility"`
+	RequestAccessEnabled bool   `json:"request_access_enabled"`
 }
 
 type gitlabCreateProjectRequest struct {


### PR DESCRIPTION
Add some functionalities.

### Project mirroring

Now using the flag `-m` you can create a mirror repository into another gitlab space. This is useful for backup purpose.

### Inherit group visibility

Now the subgroup inherit the group visibility