### PR TITLE
feat: add visibility inheritance and dedicated flag for project creation

### DIFF
--- a/cmd/gitlabCreateProjectCmd.go
+++ b/cmd/gitlabCreateProjectCmd.go
@@ -38,6 +38,11 @@ var gitlabCreateProjectCmd = &cobra.Command{
   Create a project with name "Anonymous" disabling shared runners
   opsi gitlab create project Anonymous -r
 
+  ---
+
+  Create a project with visibility "internal"
+  opsi gitlab create project Anonymous -i internal
+
 	`,
 
 	Run: func(cmd *cobra.Command, args []string) {
@@ -50,6 +55,7 @@ var gitlabCreateProjectCmd = &cobra.Command{
 		defaultBranch, _ := cmd.Flags().GetString("branch-default")
 		mirror, _ := cmd.Flags().GetBool("mirror")
 		sharedRunners, _ := cmd.Flags().GetBool("sharedrunners")
+		visibility, _ := cmd.Flags().GetString("visibility")
 
 		// Slugify the name if the pathname flag
 		// for the project is not provided
@@ -65,6 +71,7 @@ var gitlabCreateProjectCmd = &cobra.Command{
 			defaultBranch,
 			mirror,
 			sharedRunners,
+			visibility,
 		)
 
 		if err != nil {
@@ -83,6 +90,7 @@ func init() {
 	gitlabCreateProjectCmd.Flags().StringP("branch-default", "b", "main", "the default main branch. Possible values are master or main")
 	gitlabCreateProjectCmd.Flags().BoolP("mirror", "m", false, "Enable or disable the mirroring repo. Default is false")
 	gitlabCreateProjectCmd.Flags().BoolP("sharedrunners", "r", false, "Enable or disable the shared runners. Default is true")
+	gitlabCreateProjectCmd.Flags().StringP("visibility", "i", "", "Set the visibility of the project. Allowed values are private, public, internal")
 
 	// Mark group as required
 	gitlabCreateProjectCmd.MarkFlagRequired("group")

--- a/scopes/gitlab/defs.go
+++ b/scopes/gitlab/defs.go
@@ -18,7 +18,7 @@ type Gitlab interface {
 	CreateEnvs(string, string, string) error
 	ListEnvs(string, string) error
 	DeleteEnvs(string, string) error
-	CreateProject(string, string, int, string, bool, bool) (int, error)
+	CreateProject(string, string, int, string, bool, bool, string) (int, error)
 	CreateSubgroup(string, string, *int) (int, error)
 	CreateGroup(string, string, string) (int, error)
 	BulkSettings(*chan string) error
@@ -64,6 +64,7 @@ type gitlabSubgroupResponse struct {
 type gitlabCreateProjectRequest struct {
 	Name                         string `json:"name"`
 	Path                         string `json:"path"`
+	Visibility                   string `json:"visibility"`
 	NamespaceID                  int    `json:"namespace_id"`
 	MergeMethod                  string `json:"merge_method"`
 	AnalyticsAccessLevel         string `json:"analytics_access_level"`
@@ -131,6 +132,7 @@ type gitlabCreateEnvRequest struct {
 
 var defaultGitlabCreatePayload = gitlabCreateProjectRequest{
 	MergeMethod:                  "ff",
+	Visibility:                   "private",
 	AnalyticsAccessLevel:         "disabled",
 	SecurityAndComplianceEnabled: false,
 	IssuesEnabled:                false,


### PR DESCRIPTION
During che project creation, now the project visibility is inherited from the container group. Also, the user can use the -i flag for set a different visibility.